### PR TITLE
feat: Make `types` more intuitive

### DIFF
--- a/.changeset/nervous-dryers-buy.md
+++ b/.changeset/nervous-dryers-buy.md
@@ -1,0 +1,9 @@
+---
+'fuels-react': patch
+---
+
+feat: Make `types` more intuitive
+
+- `BN` -> `string`
+- Add missing `onSuccess` and `onError` callbacks
+- Allow to pass `null` as transaction request to useTransactionCost()

--- a/examples/vite/src/hooks/useCounter.ts
+++ b/examples/vite/src/hooks/useCounter.ts
@@ -3,11 +3,11 @@ import { useContract } from 'fuels-react';
 import type { CounterAbi } from '../contracts';
 import abi from '../contracts/Counter-abi.json';
 
-const contractId = '0x90efcc9a055fe39c840ccf785e63f7b062363e5a14c51854d616e17c20b40d74';
+const address = '0x90efcc9a055fe39c840ccf785e63f7b062363e5a14c51854d616e17c20b40d74';
 
 function useCounter() {
   const queryClient = useQueryClient();
-  const contract = useContract<CounterAbi>({ contractId, abi });
+  const contract = useContract<CounterAbi>({ address, abi });
 
   const { data, error, isLoading, isSuccess } = useQuery({
     queryKey: ['counter'],

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -61,6 +61,13 @@ class TransactionNotFound extends Error {
   }
 }
 
+class TransactionRequestNotCorrect extends Error {
+  constructor(message?: string) {
+    super(message);
+    Object.setPrototypeOf(this, TransactionRequestNotCorrect.prototype);
+  }
+}
+
 export {
   AddressNotCorrect,
   BlockNotFound,
@@ -68,6 +75,7 @@ export {
   ProviderNotDefined,
   TransactionIDNotCorrect,
   TransactionNotFound,
+  TransactionRequestNotCorrect,
   UserAlreadyConnected,
   UserAlreadyDisconnected,
   UserWalletNotDefined,

--- a/packages/core/src/hooks/useBalance.ts
+++ b/packages/core/src/hooks/useBalance.ts
@@ -1,6 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
 import { Address, NativeAssetId } from 'fuels';
-import type { BytesLike } from 'fuels';
 import { useSnapshot } from 'valtio';
 import { providerStore } from '../stores';
 import { AddressNotCorrect, ProviderNotDefined } from '../errors';
@@ -8,7 +7,7 @@ import type { BaseUseQueryConfig, BaseUseQueryResult } from '../types';
 
 type UseBalanceConfig = BaseUseQueryConfig<string> & {
   address: string | null;
-  assetId?: BytesLike;
+  assetId?: string;
 };
 
 function useBalance(config: UseBalanceConfig): BaseUseQueryResult<string> {

--- a/packages/core/src/hooks/useBalances.ts
+++ b/packages/core/src/hooks/useBalances.ts
@@ -6,12 +6,17 @@ import { providerStore } from '../stores';
 import { AddressNotCorrect, ProviderNotDefined } from '../errors';
 import type { BaseUseQueryConfig, BaseUseQueryResult } from '../types';
 
-type UseBalancesConfig = BaseUseQueryConfig<CoinQuantity[]> & {
+type CoinBalance = Omit<CoinQuantity, 'amount' | 'max'> & {
+  amount: string;
+  max?: string | undefined;
+};
+
+type UseBalancesConfig = BaseUseQueryConfig<CoinBalance[]> & {
   address: string | null;
   pagination?: CursorPaginationArgs;
 };
 
-function useBalances(config: UseBalancesConfig): BaseUseQueryResult<CoinQuantity[]> {
+function useBalances(config: UseBalancesConfig): BaseUseQueryResult<CoinBalance[]> {
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, status, error, isError, isFetching, isLoading, isSuccess } = useQuery({
@@ -21,7 +26,11 @@ function useBalances(config: UseBalancesConfig): BaseUseQueryResult<CoinQuantity
       if (!config.address) throw AddressNotCorrect;
       const address = Address.fromString(config.address);
       const balances = await defaultProvider.getBalances(address, config.pagination);
-      return balances.toString();
+      return balances.map((balance) => ({
+        amount: balance.amount.toString(),
+        assetId: balance.assetId,
+        max: balance.max?.toString(),
+      }));
     },
     onSuccess: config.onSuccess,
     onError: config.onError,

--- a/packages/core/src/hooks/useBlock.ts
+++ b/packages/core/src/hooks/useBlock.ts
@@ -1,9 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
-import type { Block } from 'fuels';
+import type { Block as FuelBlock } from 'fuels';
 import { useSnapshot } from 'valtio';
 import { BlockNotFound, ProviderNotDefined } from '../errors';
 import { providerStore } from '../stores';
 import type { BaseUseQueryConfig, BaseUseQueryResult } from '../types';
+
+type Block = Omit<FuelBlock, 'height'> & {
+  height: string;
+};
 
 export type UseBlockConfig<T = Block> = BaseUseQueryConfig<T> & {
   idOrHeight: string | number | null;
@@ -33,7 +37,12 @@ function useBlock(config: UseBlockConfig): UseBlockResult {
 
       const block = await defaultProvider.getBlock(blockId);
       if (!block) throw BlockNotFound;
-      return block;
+      return {
+        id: block.id,
+        height: block.height.toString(),
+        time: block.time,
+        transactionId: block.transactionIds,
+      };
     },
     onSuccess: config.onSuccess,
     onError: config.onError,

--- a/packages/core/src/hooks/useBlockWithTransactions.ts
+++ b/packages/core/src/hooks/useBlockWithTransactions.ts
@@ -5,7 +5,12 @@ import type { UseBlockConfig, UseBlockResult } from './useBlock';
 import { BlockNotFound, ProviderNotDefined } from '../errors';
 import { providerStore } from '../stores';
 
-type BlockWithTransactions = NonNullable<Awaited<ReturnType<Provider['getBlockWithTransactions']>>>;
+type BlockWithTransactions = Omit<
+  NonNullable<Awaited<ReturnType<Provider['getBlockWithTransactions']>>>,
+  'height'
+> & {
+  height: string;
+};
 
 function useBlockWithTransactions(
   config: UseBlockConfig<BlockWithTransactions>,
@@ -31,7 +36,13 @@ function useBlockWithTransactions(
 
       const block = await defaultProvider.getBlockWithTransactions(blockId);
       if (!block) throw BlockNotFound;
-      return block;
+      return {
+        id: block.id,
+        height: block.height.toString(),
+        time: block.time,
+        transactionId: block.transactionIds,
+        transactions: block.transactions,
+      };
     },
     onSuccess: config.onSuccess,
     onError: config.onError,

--- a/packages/core/src/hooks/useChains.ts
+++ b/packages/core/src/hooks/useChains.ts
@@ -2,12 +2,12 @@ import { useSnapshot } from 'valtio';
 import { providerStore } from '../stores';
 import type { Chain } from '../stores';
 
-type UseChainResult = {
+type UseChainsResult = {
   currentChain: Chain | null;
   chains: Chain[] | null;
 };
 
-function useChains(): UseChainResult {
+function useChains(): UseChainsResult {
   const { currentChain, chains } = useSnapshot(providerStore);
   return { currentChain, chains };
 }

--- a/packages/core/src/hooks/useConnect.ts
+++ b/packages/core/src/hooks/useConnect.ts
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useSnapshot } from 'valtio';
 import { connect as connect_, userStore } from '../stores';
 import type { UserStatus } from '../stores';
-import type { BaseUseMutationResult } from '../types';
+import type { BaseUseMutationConfig, BaseUseMutationResult } from '../types';
 
 type UseConnectResult = Omit<BaseUseMutationResult, 'data' | 'status'> & {
   isConnected: boolean;
@@ -12,12 +12,14 @@ type UseConnectResult = Omit<BaseUseMutationResult, 'data' | 'status'> & {
   connectAsync: () => Promise<void>;
 };
 
-function useConnect(): UseConnectResult {
+function useConnect(config?: BaseUseMutationConfig): UseConnectResult {
   const store = useSnapshot(userStore);
 
   const { mutate, mutateAsync, error, isError, isLoading, isSuccess } = useMutation({
     mutationKey: ['connect'],
     mutationFn: async () => connect_(),
+    onSuccess: config?.onSuccess,
+    onError: config?.onError,
   });
 
   const connect = useCallback(() => {

--- a/packages/core/src/hooks/useContract.ts
+++ b/packages/core/src/hooks/useContract.ts
@@ -6,13 +6,13 @@ import { ProviderNotDefined } from '../errors';
 import { providerStore, userStore } from '../stores';
 
 type UseContractConfig = {
-  contractId: string | AbstractAddress;
+  address: string | AbstractAddress;
   abi: JsonAbi | Interface;
   signerOrProvider?: BaseWalletLocked | Provider;
 };
 
 function useContract<T extends Contract>(config: UseContractConfig): T | null {
-  const { contractId, abi, signerOrProvider } = config;
+  const { address, abi, signerOrProvider } = config;
 
   const { defaultProvider } = useSnapshot(providerStore);
   const [contract, setContract] = useState<Contract | null>(null);
@@ -30,7 +30,7 @@ function useContract<T extends Contract>(config: UseContractConfig): T | null {
         walletOrProvider = userStore.wallet;
       }
 
-      const contract = new Contract(contractId, abi, walletOrProvider);
+      const contract = new Contract(address, abi, walletOrProvider);
       setContract(contract);
     };
 

--- a/packages/core/src/hooks/useDisconnect.ts
+++ b/packages/core/src/hooks/useDisconnect.ts
@@ -3,7 +3,7 @@ import { useMutation } from '@tanstack/react-query';
 import { useSnapshot } from 'valtio';
 import { disconnect as disconnect_, userStore } from '../stores';
 import type { UserStatus } from '../stores';
-import type { BaseUseMutationResult } from '../types';
+import type { BaseUseMutationConfig, BaseUseMutationResult } from '../types';
 
 type UseDisconnectResult = Omit<BaseUseMutationResult, 'data' | 'status'> & {
   isConnected: boolean;
@@ -12,12 +12,14 @@ type UseDisconnectResult = Omit<BaseUseMutationResult, 'data' | 'status'> & {
   disconnectAsync: () => Promise<void>;
 };
 
-function useDisconnect(): UseDisconnectResult {
+function useDisconnect(config?: BaseUseMutationConfig): UseDisconnectResult {
   const store = useSnapshot(userStore);
 
   const { mutate, mutateAsync, error, isError, isLoading, isSuccess } = useMutation({
     mutationKey: ['disconnect'],
     mutationFn: async () => disconnect_(),
+    onSuccess: config?.onSuccess,
+    onError: config?.onError,
   });
 
   const disconnect = useCallback(() => {

--- a/packages/core/src/hooks/useLatestBlockNumber.ts
+++ b/packages/core/src/hooks/useLatestBlockNumber.ts
@@ -8,7 +8,7 @@ type UseLatestBlockNumberConfig = BaseUseQueryConfig<string> & {
   refetchInterval?: number | false;
 };
 
-function useLatestBlockNumber(options?: UseLatestBlockNumberConfig): BaseUseQueryResult<string> {
+function useLatestBlockNumber(config?: UseLatestBlockNumberConfig): BaseUseQueryResult<string> {
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, status, error, isError, isLoading, isFetching, isSuccess } = useQuery({
@@ -18,9 +18,9 @@ function useLatestBlockNumber(options?: UseLatestBlockNumberConfig): BaseUseQuer
       const blockNumber = await defaultProvider.getBlockNumber();
       return blockNumber.toString();
     },
-    onSuccess: options?.onSuccess,
-    onError: options?.onError,
-    refetchInterval: options?.refetchInterval,
+    onSuccess: config?.onSuccess,
+    onError: config?.onError,
+    refetchInterval: config?.refetchInterval,
   });
 
   return {

--- a/packages/core/src/hooks/useProvider.ts
+++ b/packages/core/src/hooks/useProvider.ts
@@ -5,8 +5,8 @@ import { providerStore } from '../stores';
 import type { Chain } from '../stores';
 
 type UseProviderResult = {
-  chains: Chain[] | null;
   provider: Provider;
+  chains: Chain[] | null;
 };
 
 function useProvider(): UseProviderResult {

--- a/packages/core/src/hooks/useTransactionCost.ts
+++ b/packages/core/src/hooks/useTransactionCost.ts
@@ -2,13 +2,13 @@ import { useQuery } from '@tanstack/react-query';
 import type { Provider, TransactionRequestLike } from 'fuels';
 import { useSnapshot } from 'valtio';
 import { providerStore } from '../stores';
-import { ProviderNotDefined } from '../errors';
+import { ProviderNotDefined, TransactionRequestNotCorrect } from '../errors';
 import { BaseUseQueryConfig, BaseUseQueryResult } from '../types';
 
 type TransactionCostResponse = Awaited<ReturnType<Provider['getTransactionCost']>>;
 
 type UseTransactionCostConfig = BaseUseQueryConfig<TransactionCostResponse> & {
-  transactionRequest: TransactionRequestLike;
+  transactionRequest: TransactionRequestLike | null;
   tolerance?: number;
 };
 
@@ -21,6 +21,7 @@ function useTransactionCost(
     queryKey: ['transactionCost'],
     queryFn: async () => {
       if (!defaultProvider) throw ProviderNotDefined;
+      if (!config.transactionRequest) throw TransactionRequestNotCorrect;
       const transactionCost = await defaultProvider.getTransactionCost(
         config.transactionRequest,
         config.tolerance,
@@ -29,6 +30,7 @@ function useTransactionCost(
     },
     onSuccess: config.onSuccess,
     onError: config.onError,
+    enabled: !!config.transactionRequest,
   });
 
   return {

--- a/packages/core/src/hooks/useWallet.ts
+++ b/packages/core/src/hooks/useWallet.ts
@@ -3,6 +3,12 @@ import { useMutation } from '@tanstack/react-query';
 import { useSnapshot } from 'valtio';
 import { connect as connect_, disconnect as disconnect_, userStore } from '../stores';
 import type { UserStore } from '../stores';
+import type { BaseUseMutationConfig } from '../types';
+
+type UseWalletConfig = {
+  onConnect?: BaseUseMutationConfig['onSuccess'];
+  onDisconnect?: BaseUseMutationConfig['onSuccess'];
+};
 
 type UseWalletResult = UserStore & {
   isConnected: boolean;
@@ -13,17 +19,19 @@ type UseWalletResult = UserStore & {
   disconnectAsync: () => Promise<void>;
 };
 
-function useWallet(): UseWalletResult {
+function useWallet(config?: UseWalletConfig): UseWalletResult {
   const store = useSnapshot(userStore);
 
   const connectMutation = useMutation({
     mutationKey: ['connect'],
     mutationFn: async () => connect_(),
+    onSuccess: config?.onConnect,
   });
 
   const disconnectMutation = useMutation({
     mutationKey: ['disconnect'],
     mutationFn: async () => disconnect_(),
+    onSuccess: config?.onDisconnect,
   });
 
   const connect = useCallback(() => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,7 @@ export type BaseUseQueryResult<TData> = Pick<
   'data' | 'status' | 'error' | 'isError' | 'isFetching' | 'isLoading' | 'isSuccess'
 >;
 
-export type BaseUseMutationConfig<TData, TVariables = void> = Pick<
+export type BaseUseMutationConfig<TData = void, TVariables = void> = Pick<
   UseMutationOptions<TData, unknown, TVariables>,
   'onError' | 'onSuccess'
 >;


### PR DESCRIPTION
- `BN` -> `string`
- Add missing `onSuccess` and `onError` callbacks
- Allow to pass `null` as transaction request to `useTransactionCost()`
- Rename `options` to `config` in `useLatestBlockNumber()`