### PR TITLE
fix: make `queries` re-run on parameter changes

### DIFF
--- a/.changeset/young-berries-decide.md
+++ b/.changeset/young-berries-decide.md
@@ -1,0 +1,12 @@
+---
+'fuels-react': patch
+---
+
+fix: make `queries` re-run on parameter changes
+
+- useBalance()
+- useBalances()
+- useCoins()
+- useMessages()
+- useBlockWithTransactions()
+- useTransactionCost()

--- a/packages/core/src/hooks/accounts/useBalance.ts
+++ b/packages/core/src/hooks/accounts/useBalance.ts
@@ -14,7 +14,7 @@ function useBalance(config: UseBalanceConfig): BaseUseQueryResult<string> {
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, status, error, isError, isFetching, isLoading, isSuccess } = useQuery({
-    queryKey: ['balance'],
+    queryKey: ['balance', config.address],
     queryFn: async () => {
       if (!defaultProvider) throw ProviderNotDefined;
       if (!config.address) throw AddressNotCorrect;

--- a/packages/core/src/hooks/accounts/useBalances.ts
+++ b/packages/core/src/hooks/accounts/useBalances.ts
@@ -20,7 +20,7 @@ function useBalances(config: UseBalancesConfig): BaseUseQueryResult<CoinBalance[
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, status, error, isError, isFetching, isLoading, isSuccess } = useQuery({
-    queryKey: ['balances'],
+    queryKey: ['balances', config.address],
     queryFn: async () => {
       if (!defaultProvider) throw ProviderNotDefined;
       if (!config.address) throw AddressNotCorrect;

--- a/packages/core/src/hooks/accounts/useCoins.ts
+++ b/packages/core/src/hooks/accounts/useCoins.ts
@@ -12,14 +12,14 @@ type UseCoinsConfig = BaseUseQueryConfig<Coin[]> & {
   pagination?: CursorPaginationArgs;
 };
 
-function useCoins(config?: UseCoinsConfig): BaseUseQueryResult<Coin[]> {
+function useCoins(config: UseCoinsConfig): BaseUseQueryResult<Coin[]> {
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, status, error, isError, isLoading, isFetching, isSuccess } = useQuery({
-    queryKey: ['coins'],
+    queryKey: ['coins', config.address],
     queryFn: async () => {
       if (!defaultProvider) throw ProviderNotDefined;
-      if (!config?.address) throw AddressNotCorrect;
+      if (!config.address) throw AddressNotCorrect;
       const address = Address.fromString(config.address);
       const coins = await defaultProvider.getCoins(address, config.assetId, config.pagination);
       return coins;

--- a/packages/core/src/hooks/accounts/useMessages.ts
+++ b/packages/core/src/hooks/accounts/useMessages.ts
@@ -12,14 +12,14 @@ type UseMessagesConfig = BaseUseQueryConfig<Message[]> & {
   refetchInterval?: number | false;
 };
 
-function useMessages(config?: UseMessagesConfig): BaseUseQueryResult<Message[]> {
+function useMessages(config: UseMessagesConfig): BaseUseQueryResult<Message[]> {
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, status, error, isError, isLoading, isFetching, isSuccess } = useQuery({
-    queryKey: ['messages'],
+    queryKey: ['messages', config.address],
     queryFn: async () => {
       if (!defaultProvider) throw ProviderNotDefined;
-      if (!config?.address) throw AddressNotCorrect;
+      if (!config.address) throw AddressNotCorrect;
       const address = Address.fromString(config.address);
       const messages = await defaultProvider.getMessages(address, config.pagination);
       return messages;

--- a/packages/core/src/hooks/networks/useBlockWithTransactions.ts
+++ b/packages/core/src/hooks/networks/useBlockWithTransactions.ts
@@ -18,7 +18,7 @@ function useBlockWithTransactions(
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, error, status, isError, isFetching, isLoading, isSuccess } = useQuery({
-    queryKey: ['block', config.idOrHeight],
+    queryKey: ['blockWithTransactions', config.idOrHeight],
     queryFn: async () => {
       if (!defaultProvider) throw ProviderNotDefined;
       if (!config.idOrHeight) throw BlockNotFound;

--- a/packages/core/src/hooks/transactions/useTransactionCost.ts
+++ b/packages/core/src/hooks/transactions/useTransactionCost.ts
@@ -18,7 +18,7 @@ function useTransactionCost(
   const { defaultProvider } = useSnapshot(providerStore);
 
   const { data, status, error, isError, isLoading, isFetching, isSuccess } = useQuery({
-    queryKey: ['transactionCost'],
+    queryKey: ['transactionCost', config.transactionRequest],
     queryFn: async () => {
       if (!defaultProvider) throw ProviderNotDefined;
       if (!config.transactionRequest) throw TransactionRequestNotCorrect;


### PR DESCRIPTION
Hooks:

- useBalance()
- useBalances()
- useCoins()
- useMessages()
- useBlockWithTransactions()
- useTransactionCost()